### PR TITLE
add partial support for NodeJS@8.1.4

### DIFF
--- a/context.js
+++ b/context.js
@@ -5,11 +5,13 @@ const util = require('util');
 const assert = require('assert');
 const wrapEmitter = require('emitter-listener');
 const async_hooks = require('async_hooks');
+const semver = require('semver');
 
 const CONTEXTS_SYMBOL = 'cls@contexts';
 const ERROR_SYMBOL = 'error@context';
 
 const DEBUG_CLS_HOOKED = process.env.DEBUG_CLS_HOOKED;
+const getCurrentUid = semver.gte(process.versions.node, '8.2.0') ? async_hooks.executionAsyncId : () => async_hooks.currentId;
 
 let currentUid = -1;
 
@@ -288,7 +290,7 @@ function createNamespace(name) {
 
   const hook = async_hooks.createHook({
     init(asyncId, type, triggerId, resource) {
-      currentUid = async_hooks.executionAsyncId();
+      currentUid = getCurrentUid();
 
       //CHAIN Parent's Context onto child if none exists. This is needed to pass net-events.spec
       // let initContext = namespace.active;
@@ -346,7 +348,8 @@ function createNamespace(name) {
 
     },
     before(asyncId) {
-      currentUid = async_hooks.executionAsyncId();
+      currentUid = getCurrentUid();
+
       let context;
 
       /*
@@ -381,7 +384,8 @@ function createNamespace(name) {
       }
     },
     after(asyncId) {
-      currentUid = async_hooks.executionAsyncId();
+      currentUid = getCurrentUid();
+
       let context; // = namespace._contexts.get(currentUid);
       /*
       if(currentUid === 0){
@@ -414,7 +418,8 @@ function createNamespace(name) {
       }
     },
     destroy(asyncId) {
-      currentUid = async_hooks.executionAsyncId();
+      currentUid = getCurrentUid();
+
       if (DEBUG_CLS_HOOKED) {
         const triggerId = async_hooks.triggerAsyncId();
         const indentStr = ' '.repeat(namespace._indent < 0 ? 0 : namespace._indent);
@@ -473,5 +478,3 @@ function debug2(...args) {
     return fn.constructor.name;
   }
 }*/
-
-

--- a/test/net-events.test.js
+++ b/test/net-events.test.js
@@ -31,14 +31,14 @@ describe('cls with net connection', () => {
 
           testValue1 = namespace.get('test');
 
-          socket.on('data', () => {
+          socket.on('data', namespace.bind(() => {
             testValue2 = namespace.get('test');
             server.close();
             socket.end('GoodBye');
 
             serverDone = true;
             checkDone();
-          });
+          }));
 
         });
 

--- a/test/net-events2.test.js
+++ b/test/net-events2.test.js
@@ -25,14 +25,14 @@ describe('cls with net connection 2', function() {
         server.on('connection', function OnServerConnection(socket) {
             expect(namespace.get(keyName)).equal(TEST_VALUE, 'state has been mutated');
 
-            socket.on('data', function OnServerSocketData(data) {
+            socket.on('data', namespace.bind(function OnServerSocketData(data) {
               data = data.toString('utf-8');
               expect(data).equal(DATUM1, 'should get DATUM1');
               expect(namespace.get(keyName)).equal(TEST_VALUE, 'state is still preserved');
 
               socket.end(DATUM2);
               server.close();
-            });
+            }));
           }
         );
 

--- a/test/tap/net-events.tap.js
+++ b/test/tap/net-events.tap.js
@@ -17,11 +17,11 @@ test('continuation-local state with net connection', function(t) {
 
       server = net.createServer(function(socket) {
         t.equal(namespace.get('test'), 'newContextValue', 'state has been mutated');
-        socket.on('data', function() {
+        socket.on('data', namespace.bind(function() {
           t.equal(namespace.get('test'), 'newContextValue', 'state is still preserved');
           server.close();
           socket.end('GoodBye');
-        });
+        }));
       });
       server.listen(function() {
         var address = server.address();


### PR DESCRIPTION
This is intended to fix the issues outlined in this issue: https://github.com/Jeff-Lewis/cls-hooked/issues/13

This works with the exception of two things:
- The `currentId` getter on the async_hooks API needs to be used instead of `getExecutionId`. This is because in NodeJS@8.1.4, the `getExecutionId` method does not exist. In NodeJS@>=8.2.0, or at some time previous to NodeJS@8.8.1, the `currentId` getter was deprecated (https://nodejs.org/api/deprecations.html#deprecations_dep0070_async_hooks_currentid). A helper has been added to assuage that gap, with a check to determine which to use based on semver/NodeJS version.
- The `net` module EventEmitter callbacks for data do not work. This likely has something to do with the nesting of additional asynchronous callbacks. It appears as though the tests were designed intentionally to test this behavior and it is likely *unwise to merge the PR as-is as a result*. The way the `net` callbacks were fixed was to add an additional `namespace.bind` surrounding their definition, which is why I've marked this PR as _partial_ support. 

@Jeff-Lewis, I'm looking for some input as to how I should continue here in this respect, whether it be resetting the tests, or wrapping them in a check for NodeJS version, and adding additional documentation for NodeJS@>=8 <8.2, or some other behavior indicating the change.