### PR TITLE
Fix memory leak in `process.namespaces`

### DIFF
--- a/context-legacy.js
+++ b/context-legacy.js
@@ -361,7 +361,7 @@ function destroyNamespace(name) {
   assert.ok(namespace, 'can\'t delete nonexistent namespace! "' + name + '"');
   assert.ok(namespace.id, 'don\'t assign to process.namespaces directly! ' + util.inspect(namespace));
 
-  process.namespaces[name] = null;
+  delete process.namespaces[name];
 }
 
 function reset() {

--- a/context.js
+++ b/context.js
@@ -437,7 +437,7 @@ function destroyNamespace(name) {
   assert.ok(namespace, 'can\'t delete nonexistent namespace! "' + name + '"');
   assert.ok(namespace.id, 'don\'t assign to process.namespaces directly! ' + util.inspect(namespace));
 
-  process.namespaces[name] = null;
+  delete process.namespaces[name];
 }
 
 function reset() {


### PR DESCRIPTION
Numeric namespace identifiers are never removed from the global `process.namespaces` object:

https://github.com/Jeff-Lewis/cls-hooked/blob/066c6c4027a7924b06997cc6b175b1841342abdc/context.js#L440

https://github.com/Jeff-Lewis/cls-hooked/blob/066c6c4027a7924b06997cc6b175b1841342abdc/context-legacy.js#L364