### PR TITLE
AsyncHook MemoryLeak fixes

### DIFF
--- a/context.js
+++ b/context.js
@@ -442,11 +442,11 @@ function destroyNamespace(name) {
 
   namespace._hook.disable();
 
-  /**
-   * Zerofying _contexts as haviest part of Namespace
-   * in case our namespace is retained mistakenly, so
-   * we releasing heavist part at least
-   */
+  /*
+  * Zeroing _contexts as heaviest part of Namespace
+  * In case our namespace is retained mistakenly, so
+  * at least we are releasing heaviest part
+  */
   namespace._contexts = null;
 
   process.namespaces[name] = null;

--- a/context.js
+++ b/context.js
@@ -442,6 +442,13 @@ function destroyNamespace(name) {
 
   namespace._hook.disable();
 
+  /**
+   * Zerofying _contexts as haviest part of Namespace
+   * in case our namespace is retained mistakenly, so
+   * we releasing heavist part at least
+   */
+  namespace._contexts = null;
+
   process.namespaces[name] = null;
 }
 

--- a/context.js
+++ b/context.js
@@ -29,6 +29,7 @@ function Namespace(name) {
   this.id = null;
   this._contexts = new Map();
   this._indent = 0;
+  this._hook = null;
 }
 
 Namespace.prototype.set = function set(key, value) {
@@ -427,6 +428,8 @@ function createNamespace(name) {
 
   hook.enable();
 
+  namespace._hook = hook;
+
   process.namespaces[name] = namespace;
   return namespace;
 }
@@ -436,6 +439,8 @@ function destroyNamespace(name) {
 
   assert.ok(namespace, 'can\'t delete nonexistent namespace! "' + name + '"');
   assert.ok(namespace.id, 'don\'t assign to process.namespaces directly! ' + util.inspect(namespace));
+
+  namespace._hook.disable();
 
   process.namespaces[name] = null;
 }


### PR DESCRIPTION
It looks like we have to `disable` hook, when namespace is destoryed. Otherwise it would live forever and hence it would retain namespace object with all it's massive _context.

More details how I replicated and fixed the issue described here: https://github.com/liberation-data/drivine/issues/35#issuecomment-637567531