### PR TITLE
Add stack-chain Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,13 @@
       "integrity": "sha1-T9JcL4ZNuvJ5xhDXO/l7GyhZXmg=",
       "requires": {
         "stack-chain": "^1.3.7"
+      },
+      "dependencies": {
+        "stack-chain": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+          "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+        }
       }
     },
     "asynckit": {
@@ -4466,9 +4473,9 @@
       }
     },
     "stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
+      "integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg=="
     },
     "stack-utils": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "async-hook-jl": "^1.7.6",
-    "emitter-listener": "^1.0.1"
+    "emitter-listener": "^1.0.1",
+    "stack-chain": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.0",


### PR DESCRIPTION
See issue #64 - undeclared dependency on `stack-chain` is causing failures when in a strict environment. This works in non-strict environments due to package hoisting, so `stack-chain` is being resolved from some other package's dependencies, which is not an ideal situation, because if that package removes its dependency on `stack-chain` in the future and we use that version then we no longer have it for ourselves.

stack-chain is required in context-legacy.js
[var stackChain = require('stack-chain');](https://github.com/Jeff-Lewis/cls-hooked/blob/master/context-legacy.js#L416)

but it is not included in package.json dependencies
[dependencies](https://github.com/Jeff-Lewis/cls-hooked/blob/master/package.json#L37)