### PR TITLE
fix(context): fixed runPromise mem leak and incorrect propagation

### DIFF
--- a/context-legacy.js
+++ b/context-legacy.js
@@ -127,14 +127,17 @@ Namespace.prototype.runPromise = function runPromise(fn) {
   this.enter(context);
 
   let promise = fn(context);
+
   if (!promise || !promise.then || !promise.catch) {
     throw new Error('fn must return a promise.');
   }
 
   if (DEBUG_CLS_HOOKED) {
     debug2(' BEFORE runPromise: ' + this.name + ' uid:' + currentUid + ' len:' + this._set.length + ' ' +
-      util.inspect(context));
+     util.inspect(context));
   }
+
+  this.exit(context);
 
   return promise
     .then(result => {
@@ -142,7 +145,6 @@ Namespace.prototype.runPromise = function runPromise(fn) {
         debug2(' AFTER runPromise: ' + this.name + ' uid:' + currentUid + ' len:' + this._set.length + ' ' +
           util.inspect(context));
       }
-      this.exit(context);
       return result;
     })
     .catch(err => {
@@ -151,7 +153,6 @@ Namespace.prototype.runPromise = function runPromise(fn) {
         debug2(' AFTER runPromise: ' + this.name + ' uid:' + currentUid + ' len:' + this._set.length + ' ' +
           util.inspect(context));
       }
-      this.exit(context);
       throw err;
     });
 };

--- a/context.js
+++ b/context.js
@@ -138,12 +138,13 @@ Namespace.prototype.runPromise = function runPromise(fn) {
     debug2('CONTEXT-runPromise BEFORE: (' + this.name + ') currentUid:' + currentUid + ' len:' + this._set.length + ' ' + util.inspect(context));
   }
 
+  this.exit(context);
+
   return promise
     .then(result => {
       if (DEBUG_CLS_HOOKED) {
         debug2('CONTEXT-runPromise AFTER then: (' + this.name + ') currentUid:' + currentUid + ' len:' + this._set.length + ' ' + util.inspect(context));
       }
-      this.exit(context);
       return result;
     })
     .catch(err => {
@@ -151,7 +152,6 @@ Namespace.prototype.runPromise = function runPromise(fn) {
       if (DEBUG_CLS_HOOKED) {
         debug2('CONTEXT-runPromise AFTER catch: (' + this.name + ') currentUid:' + currentUid + ' len:' + this._set.length + ' ' + util.inspect(context));
       }
-      this.exit(context);
       throw err;
     });
 };


### PR DESCRIPTION
This PR is fixing:
- Issue #63. Memory leak and incorrect propagation of the `runPromise` method.
- Issue #71. The `exit` method was being called after the promise was resolved/rejected, it looks like it was not clearing the `active` property in time for the next `createContext` called on the next `runPromise`.

No side effects occured after this fix.

Tests:

1. Before fix:
![before-runpromise](https://user-images.githubusercontent.com/32373496/181652597-33b4a516-fd0d-4aa3-8b2b-2ce35bacee84.png)

2. After fix:
![after-runpromise](https://user-images.githubusercontent.com/32373496/181652605-9e28e64a-b24f-445f-99fb-0478cb42023e.png)

3. [Inner Propagation fixed](https://github.com/Jeff-Lewis/cls-hooked#continuation-local-storage--hooked-):
![after-runpromise-no-side-effect](https://user-images.githubusercontent.com/32373496/181652612-71883281-b02d-4d82-9b91-b79310e85b36.png)
