### PR TITLE
fix: bump semver to ^7.5.3 to fix audit issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4356,10 +4356,30 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
-      "dev": true
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -4563,6 +4583,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cls-hooked",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "CLS using AsyncWrap instead of async-listener - Node >= 4.7.0",
   "main": "index.js",
   "files": [
@@ -41,7 +41,7 @@
   "devDependencies": {
     "chai": "^4.1.0",
     "mocha": "^6.2.2",
-    "semver": "^6.3.0",
+    "semver": "^7.5.3",
     "sinon": "^7.5.0",
     "sinon-chai": "^3.3.0",
     "superagent": "^5.1.2",


### PR DESCRIPTION
Fixes https://github.com/Jeff-Lewis/cls-hooked/issues/78 issue with `npm audit`

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ semver vulnerable to Regular Expression Denial of Service    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ semver                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ semver [dev]                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ semver                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-c2qf-rxjj-qqgw            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```