### PR TITLE
Replace leftover usage of async_hooks.currentId in DEBUG_CLS_HOOKED

### DIFF
--- a/context.js
+++ b/context.js
@@ -49,7 +49,7 @@ Namespace.prototype.set = function set(key, value) {
 Namespace.prototype.get = function get(key) {
   if (!this.active) {
     if (DEBUG_CLS_HOOKED) {
-      const asyncHooksCurrentId = async_hooks.currentId();
+      const asyncHooksCurrentId = async_hooks.executionAsyncId();
       const triggerId = async_hooks.triggerAsyncId();
       const indentStr = ' '.repeat(this._indent < 0 ? 0 : this._indent);
       //debug2(indentStr + 'CONTEXT-GETTING KEY NO ACTIVE NS:' + key + '=undefined' + ' (' + this.name + ') currentUid:' + currentUid + ' active:' + util.inspect(this.active, {showHidden:true, depth:2, colors:true}));


### PR DESCRIPTION
Small one, it looks like this one call to async_hooks.currentId was missed in 0ebfb9b484898cd7b14fe8b5b35ecd7f17878f79.

Thanks 🙏 

